### PR TITLE
SDP-5646 Support UUIDs as app keys

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -272,10 +272,12 @@ ROX_INTERNAL RoxStateCode rox_core_setup(
         roxy_url = rox_options_get_roxy_url(rox_options);
         if (!roxy_url) {
             char *api_key = sdk_settings_get_api_key(sdk_settings);
+            char *mongoIdPattern = "^[a-f\\d]{24}$";
+            char *uuidIdPattern = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
             if (!api_key || !api_key[0]) {
                 ROX_ERROR("Invalid rollout apikey - must be specified");
                 return RoxErrorEmptyApiKey;
-            } else if (!str_matches(api_key, "^[a-f\\d]{24}$", PCRE2_CASELESS)) {
+            } else if (!str_matches(api_key, mongoIdPattern, PCRE2_CASELESS) && !str_matches(api_key, mongoIdPattern, PCRE2_CASELESS)) {
                 ROX_ERROR("Illegal rollout apikey");
                 return RoxErrorInvalidApiKey;
             }

--- a/tests/test_core.c
+++ b/tests/test_core.c
@@ -66,6 +66,24 @@ START_TEST (test_will_check_invalid_api_key) {
 
 END_TEST
 
+START_TEST (test_will_check_valid_mongo_api_key) {
+    CoreTestContext *ctx = core_test_context_create("12345678901234567890abcd", NULL);
+    RoxStateCode status = rox_core_setup(ctx->core, ctx->sdk_settings, ctx->device_properties, ctx->rox_options);
+    ck_assert_int_eq(RoxInitialized, status);
+    core_test_context_free(ctx);
+}
+
+END_TEST
+
+START_TEST (test_will_check_invalid_api_key) {
+    CoreTestContext *ctx = core_test_context_create("632d9ef0-15a3-11ee-820a-00155deb2761", NULL);
+    RoxStateCode status = rox_core_setup(ctx->core, ctx->sdk_settings, ctx->device_properties, ctx->rox_options);
+    ck_assert_int_eq(RoxInitialized, status);
+    core_test_context_free(ctx);
+}
+
+END_TEST
+
 START_TEST (test_will_check_core_setup_when_options_with_roxy) {
     CoreTestContext *ctx = core_test_context_create("doesn't matter", "http://localhost");
     RoxStateCode status = rox_core_setup(ctx->core, ctx->sdk_settings, ctx->device_properties, ctx->rox_options);


### PR DESCRIPTION
<!-- Updated by issuebot -->
![image](https://cloudbees.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium) [SDP-5646: C/C++ to support app_key as UUID](https://cloudbees.atlassian.net/browse/SDP-5646)
<!-- End of issuebot update -->
to support the new platform

There is _no_ CI set up for this module. I haven't built C projects in well over a decade